### PR TITLE
chore(ci): refresh pinned GitHub Action SHAs to latest stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
@@ -106,7 +106,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./cobertura.xml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
       - name: Install Rust 1.85.0
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: "1.85.0"
       

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f # nightly
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: nightly
       
       - name: Build documentation
         run: cargo doc --no-deps --all-features --document-private-items
@@ -30,7 +32,7 @@ jobs:
       
       - name: Deploy to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@4a2e02b36f31d8974a0d09d3bb9f3172aa2d0d0d # v3
+        uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc


### PR DESCRIPTION
### Motivation
- Keep GitHub Actions pins current to benefit from upstream fixes and avoid using outdated branch pins.
- Ensure the `rust-toolchain` action uses a stable pinned SHA while preserving the intended nightly toolchain in the docs workflow.

### Description
- Replaced `dtolnay/rust-toolchain` `master` pin usages with the latest stable pinned SHA in CI and MSRV workflows and set `with: toolchain: nightly` in the docs workflow to preserve nightly behavior.
- Upgraded `codecov/codecov-action` pin from the older `v4` SHA to the latest `v5` SHA in the coverage step.
- Upgraded `peaceiris/actions-gh-pages` pin from the `v3` SHA to the current `v4` SHA in the docs deploy step.
- Only `uses:` lines and an added small `with:` block were changed in `.github/workflows/ci.yml` and `.github/workflows/docs.yml`.

### Testing
- Resolved upstream tags/branches with `git ls-remote` to verify the latest SHAs were selected, and the resolution succeeded.
- Ran `rg "uses:" .github/workflows/*.yml` to confirm workflow `uses:` entries were updated, and the grep matched the new pins.
- Reviewed the workflow diffs with `git diff` to confirm only intended lines changed, and the diff matched expectations.
- Checked the working tree with `git status` to verify the modified workflow files were recorded, and the status showed the two updated files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2f1af0544833299f26f6147ca8821)