### PR TITLE
[codex] harden dependencies and GitHub workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,10 +9,17 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     name: Performance Benchmarks
     runs-on: [self-hosted, linux]
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-D warnings"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Suite

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,15 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     name: Build Documentation
     runs-on: [self-hosted, linux]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,15 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   create-release:
     name: Create Release
     runs-on: [self-hosted, linux]
+    permissions:
+      contents: write
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ steps.get_version.outputs.version }}
@@ -52,6 +57,8 @@ jobs:
     name: Build Release
     needs: create-release
     runs-on: ${{ (matrix.os == 'windows-latest' || matrix.os == 'macos-latest') && matrix.os || fromJSON('["self-hosted","linux"]') }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0.149"
 thiserror = "2.0.18"
 anyhow = "1.0.102"
 # Environment variables
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 # Logging
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
@@ -39,8 +39,6 @@ chrono = { version = "0.4.43", features = ["serde"] }
 # Stream utilities
 futures = "0.3.32"
 tokio-stream = "0.1.18"
-# Retry logic
-backoff = "0.4.0"
 # Rate limiting
 governor = "0.10.4"
 nonzero_ext = "0.3.0"
@@ -60,7 +58,6 @@ pretty_assertions = "1.4.1"
 serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["full", "test-util"] }
 futures-util = "0.3.32"
-async-std = "1.13.2"
 
 [features]
 default = ["native-tls"]

--- a/examples/claude_4_features.rs
+++ b/examples/claude_4_features.rs
@@ -19,7 +19,7 @@ use threatflux::{
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // Load environment variables
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     // Create client
     let client = Client::from_env()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,7 +111,7 @@ impl Config {
 
     /// Create configuration from environment variables
     pub fn from_env() -> Result<Self> {
-        dotenv::dotenv().ok(); // Ignore errors if .env file doesn't exist
+        dotenvy::dotenv().ok(); // Ignore errors if .env file doesn't exist
 
         let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
             AnthropicError::config("ANTHROPIC_API_KEY environment variable not set")

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,4 +10,4 @@ pub use rate_limit::{
     AdaptiveRateLimiter, RateLimitConfig, RateLimitError, RateLimitMiddleware, RateLimitStats,
     RateLimiter,
 };
-pub use retry::{RetryClient, RetryPolicy, RetryStats};
+pub use retry::{ExponentialBackoff, RetryClient, RetryPolicy, RetryStats};

--- a/src/utils/retry.rs
+++ b/src/utils/retry.rs
@@ -6,11 +6,73 @@ use crate::{
     types::HttpMethod,
     utils::http::{HttpClient, RateLimitInfo},
 };
-use backoff::{backoff::Backoff, ExponentialBackoff};
 use reqwest::header::HeaderMap;
 use serde::de::DeserializeOwned;
 use std::{sync::Arc, time::Duration};
 use url::Url;
+
+/// A lightweight exponential backoff state machine used by the retry client.
+#[derive(Debug, Clone)]
+pub struct ExponentialBackoff {
+    /// Initial delay between retries.
+    pub initial_interval: Duration,
+    /// Maximum delay between retries.
+    pub max_interval: Duration,
+    /// Delay growth factor applied after each attempt.
+    pub multiplier: f64,
+    /// Maximum total time the backoff sequence may consume.
+    pub max_elapsed_time: Option<Duration>,
+    /// Delay that will be returned on the next retry.
+    pub current_interval: Duration,
+    /// Total time already spent in retry delays.
+    pub elapsed_time: Duration,
+}
+
+impl Default for ExponentialBackoff {
+    fn default() -> Self {
+        Self {
+            initial_interval: Duration::from_millis(500),
+            max_interval: Duration::from_secs(60),
+            multiplier: 1.5,
+            max_elapsed_time: Some(Duration::from_secs(900)),
+            current_interval: Duration::ZERO,
+            elapsed_time: Duration::ZERO,
+        }
+    }
+}
+
+impl ExponentialBackoff {
+    /// Return the next delay in the backoff sequence.
+    pub fn next_backoff(&mut self) -> Option<Duration> {
+        let base_interval = self.initial_interval.min(self.max_interval);
+        let delay = if self.current_interval == Duration::ZERO {
+            base_interval
+        } else {
+            self.current_interval.min(self.max_interval)
+        };
+
+        if let Some(limit) = self.max_elapsed_time {
+            if self.elapsed_time >= limit || self.elapsed_time.saturating_add(delay) > limit {
+                return None;
+            }
+        }
+
+        self.elapsed_time = self.elapsed_time.saturating_add(delay);
+
+        let multiplier = if self.multiplier.is_finite() && self.multiplier > 0.0 {
+            self.multiplier
+        } else {
+            1.0
+        };
+
+        let next_delay = Duration::from_secs_f64(
+            (delay.as_secs_f64() * multiplier).min(self.max_interval.as_secs_f64()),
+        );
+        self.current_interval = next_delay.max(base_interval);
+
+        Some(delay)
+    }
+}
 
 /// Client wrapper that adds retry logic to HTTP requests
 #[derive(Clone)]

--- a/tests/real_api/real_messages_test.rs
+++ b/tests/real_api/real_messages_test.rs
@@ -7,7 +7,7 @@
 mod real_api_tests {
     use threatflux::{Client, builders::MessageBuilder};
     use std::env;
-    use dotenv::dotenv;
+    use dotenvy::dotenv;
 
     fn setup_client() -> Option<Client> {
         dotenv().ok(); // Load .env file if present

--- a/tests/unit/utils_test.rs
+++ b/tests/unit/utils_test.rs
@@ -87,7 +87,7 @@ mod http_utils_tests {
 #[cfg(test)]
 mod retry_logic_tests {
     use super::*;
-    use backoff::{ExponentialBackoff, backoff::Backoff};
+    use threatflux::utils::retry::ExponentialBackoff;
 
     #[test]
     fn test_exponential_backoff() {


### PR DESCRIPTION
## Summary
- replace unmaintained Rust dependencies by swapping `dotenv` to `dotenvy`, removing unused `async-std`, and replacing the abandoned `backoff` crate with an internal exponential backoff implementation
- enable least-privilege workflow permissions in the repo’s existing GitHub Actions workflows so the repo can safely tighten default workflow permissions later
- align retry tests and examples with the new dependency and retry implementation

## Why
Local RustSec checks identified real dependency issues in `backoff`, `dotenv`, `async-std`, and transitive `instant`. The repository also relied on broad default workflow permissions instead of declaring write scopes where they are actually required.

## Impact
- removes the RustSec advisory chain from the codebase
- keeps retry behavior in-tree and test-covered
- narrows workflow permissions for docs, benchmark, and release automation while leaving CI read-only

## Validation
- `cargo test`
- `cargo deny check advisories`
- `cargo audit`
- Ruby YAML parse over `.github/workflows/*.yml`
