### PR TITLE
[codex] Roll up Dependabot updates

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,7 +59,7 @@ jobs:
       
       - name: Store benchmark result
         if: github.event_name == 'push' && steps.run_benchmarks.outputs.has_results == 'true'
-        uses: benchmark-action/github-action-benchmark@a7bc2366eda11037936ea57d811a43b3418d3073 # v1
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1
         with:
           name: Rust Benchmarks
           tool: 'cargo'


### PR DESCRIPTION
Rolls up the currently open Dependabot updates into a single maintenance PR.

Included updates:
- #17 ci(deps): bump benchmark-action/github-action-benchmark from 1.21.0 to 1.22.0

Local validation:
- make test